### PR TITLE
Add Entity Provider support, including support for Railcraft Trains

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,19 @@ minecraft {
 
 repositories {
     maven { url "http://dvs1.progwml6.com/files/maven" }
+    ivy {
+        name = "Railcraft"
+        url = "http://www.railcraft.info/ivy/"
+    }
 }
 
 dependencies {
     deobfCompile "mezz.jei:jei_${config.minecraft.version}:${config.jei.version}"
     deobfCompile "mod.chiselsandbits:chiselsandbits:${config.chiselsandbits.version}"
+    deobfCompile  ( "com.headlamp-games:Railcraft:${config.railcraft.version}"){
+        exclude module: "forestry_1.10.2"
+        exclude module: "industrialcraft-2"
+    }
 }
 
 processResources {

--- a/build.properties
+++ b/build.properties
@@ -8,5 +8,6 @@ mod.version=1.0.5
 
 chiselsandbits.version=12.0.54
 jei.version=3.14.7.417
+railcraft.version=[10.1.2-beta-4,11.0.0)
 
 maven.url=file:///home/www/maven.cil.li/web

--- a/src/main/java/li/cil/architect/client/renderer/OverlayRendererUtils.java
+++ b/src/main/java/li/cil/architect/client/renderer/OverlayRendererUtils.java
@@ -7,6 +7,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -82,7 +83,7 @@ final class OverlayRendererUtils {
         final VertexBuffer buffer = t.getBuffer();
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 
-        drawCube((int) bounds.minX, (int) bounds.minY, (int) bounds.minZ, (int) bounds.maxX, (int) bounds.maxY, (int) bounds.maxZ, buffer);
+        drawCube(bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ, buffer);
 
         t.draw();
     }
@@ -108,7 +109,7 @@ final class OverlayRendererUtils {
         final VertexBuffer buffer = t.getBuffer();
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 
-        drawCube((int) bounds.minX, (int) bounds.minY, (int) bounds.minZ, (int) bounds.maxX, (int) bounds.maxY, (int) bounds.maxZ, buffer);
+        drawCube(bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ, buffer);
 
         t.draw();
 
@@ -189,6 +190,43 @@ final class OverlayRendererUtils {
         GlStateManager.enableTexture2D();
         GlStateManager.disableBlend();
         GlStateManager.popMatrix();
+    }
+
+    static void renderEntitySelector(Entity entity, float dt) {
+        final float offset = (float) (entity.getEntityId()) % TWO_PI;
+        final float sin = MathHelper.sin(offset + dt);
+        final float scale = SCALE_STRENGTH * sin;
+        final float yaw = 90 * sin;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(entity.posX, entity.posY, entity.posZ);
+        GlStateManager.rotate(180F - yaw, 0, 1, 0);
+
+        renderCube(getEntityBoundingBox(entity, scale));
+        GlStateManager.popMatrix();
+    }
+
+    static void renderEntitySelectorWire(Entity entity, float dt) {
+        final float offset = (float) (entity.getEntityId()) % TWO_PI;
+        final float sin = MathHelper.sin(offset + dt);
+        final float scale = SCALE_STRENGTH * sin;
+        final float yaw = 90 * sin;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(entity.posX, entity.posY, entity.posZ);
+        GlStateManager.rotate(180F - yaw, 0, 1, 0);
+
+        renderCubeWire(getEntityBoundingBox(entity, scale));
+        GlStateManager.popMatrix();
+    }
+
+    private static AxisAlignedBB getEntityBoundingBox(Entity entity, float scale) {
+        AxisAlignedBB boundingBox = entity.getEntityBoundingBox();
+        boundingBox = boundingBox.offset(
+                -boundingBox.minX - (boundingBox.maxX - boundingBox.minX) / 2.0,
+                -boundingBox.minY,
+                -boundingBox.minZ - (boundingBox.maxZ - boundingBox.minZ) / 2.0);
+        return boundingBox.expandXyz(scale);
     }
 
     static void drawCube(final BlockPos pos, final VertexBuffer buffer, final float dt) {

--- a/src/main/java/li/cil/architect/client/renderer/ProviderRenderer.java
+++ b/src/main/java/li/cil/architect/client/renderer/ProviderRenderer.java
@@ -18,7 +18,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.items.CapabilityItemHandler;
 import org.lwjgl.opengl.GL11;
 
 import static li.cil.architect.client.renderer.OverlayRendererUtils.*;
@@ -48,7 +47,7 @@ public enum ProviderRenderer {
             if (hit.typeOfHit == RayTraceResult.Type.BLOCK) {
                 final BlockPos hitPos = hit.getBlockPos();
                 final TileEntity tileEntity = mc.world.getTileEntity(hitPos);
-                if (tileEntity != null && tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, hit.sideHit)) {
+                if (tileEntity != null && ((AbstractProvider) stack.getItem()).isValidTarget(tileEntity, hit.sideHit)) {
                     final EnumFacing side = hit.sideHit;
 
                     doWirePrologue();
@@ -60,7 +59,7 @@ public enum ProviderRenderer {
                 }
             } else if (hit.typeOfHit == RayTraceResult.Type.ENTITY) {
                 final Entity entity = hit.entityHit;
-                if (entity != null && entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)) {
+                if (entity != null && ((AbstractProvider) stack.getItem()).isValidTarget(entity)) {
 
                     doWirePrologue();
                     GlStateManager.color(0.2f, 0.9f, 0.4f, 1f);

--- a/src/main/java/li/cil/architect/client/renderer/ProviderRenderer.java
+++ b/src/main/java/li/cil/architect/client/renderer/ProviderRenderer.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -43,22 +44,33 @@ public enum ProviderRenderer {
         final float dt = computeScaleOffset();
 
         final RayTraceResult hit = mc.objectMouseOver;
-        if (hit != null && hit.typeOfHit == RayTraceResult.Type.BLOCK) {
-            final BlockPos hitPos = hit.getBlockPos();
-            final TileEntity tileEntity = mc.world.getTileEntity(hitPos);
-            if (tileEntity != null && tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, hit.sideHit)) {
-                final EnumFacing side = hit.sideHit;
+        if (hit != null) {
+            if (hit.typeOfHit == RayTraceResult.Type.BLOCK) {
+                final BlockPos hitPos = hit.getBlockPos();
+                final TileEntity tileEntity = mc.world.getTileEntity(hitPos);
+                if (tileEntity != null && tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, hit.sideHit)) {
+                    final EnumFacing side = hit.sideHit;
 
-                doWirePrologue();
-                GlStateManager.color(0.2f, 0.9f, 0.4f, 0.4f);
-                renderCubePulsing(hitPos, dt);
-                GlStateManager.color(0.2f, 0.9f, 0.4f, 0.8f);
-                renderSide(hitPos, side);
-                doWireEpilogue();
+                    doWirePrologue();
+                    GlStateManager.color(0.2f, 0.9f, 0.4f, 0.4f);
+                    renderCubePulsing(hitPos, dt);
+                    GlStateManager.color(0.2f, 0.9f, 0.4f, 0.8f);
+                    renderSide(hitPos, side);
+                    doWireEpilogue();
+                }
+            } else if (hit.typeOfHit == RayTraceResult.Type.ENTITY) {
+                final Entity entity = hit.entityHit;
+                if (entity != null && entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)) {
+
+                    doWirePrologue();
+                    GlStateManager.color(0.2f, 0.9f, 0.4f, 1f);
+                    renderEntitySelectorWire(entity, dt);
+                    doWireEpilogue();
+                }
             }
         }
 
-        if (AbstractProvider.isBound(stack)) {
+        if (AbstractProvider.isBoundToBlock(stack)) {
             if (AbstractProvider.getDimension(stack) == player.getEntityWorld().provider.getDimension()) {
                 final BlockPos pos = AbstractProvider.getPosition(stack);
                 if (player.getDistanceSq(pos) <= 64 * 64) {
@@ -68,6 +80,15 @@ public enum ProviderRenderer {
                     renderCubePulsing(pos, dt);
                     GlStateManager.color(0.2f, 0.9f, 0.4f, 0.8f);
                     renderSide(pos, side);
+                }
+            }
+        } else if (AbstractProvider.isBoundToEntity(stack)) {
+            if (AbstractProvider.getDimension(stack) == player.getEntityWorld().provider.getDimension()) {
+                Entity entity = AbstractProvider.getEntity(stack, mc.world);
+                if (entity != null && player.getDistanceSqToEntity(entity) <= 64 * 64) {
+
+                    GlStateManager.color(0.2f, 0.9f, 0.4f, 0.4f);
+                    renderEntitySelector(entity, dt);
                 }
             }
         }

--- a/src/main/java/li/cil/architect/common/integration/Integration.java
+++ b/src/main/java/li/cil/architect/common/integration/Integration.java
@@ -2,6 +2,7 @@ package li.cil.architect.common.integration;
 
 import li.cil.architect.common.integration.chiselsandbits.ProxyChiselsAndBits;
 import li.cil.architect.common.integration.minecraft.ProxyMinecraft;
+import li.cil.architect.common.integration.railcraft.ProxyRailcraft;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -18,6 +19,7 @@ public final class Integration {
     static {
         proxies.add(new ProxyMinecraft());
         proxies.add(new ProxyChiselsAndBits());
+        proxies.add(new ProxyRailcraft());
     }
 
     // --------------------------------------------------------------------- //

--- a/src/main/java/li/cil/architect/common/integration/railcraft/ProxyRailcraft.java
+++ b/src/main/java/li/cil/architect/common/integration/railcraft/ProxyRailcraft.java
@@ -1,0 +1,38 @@
+package li.cil.architect.common.integration.railcraft;
+
+import li.cil.architect.common.integration.ModProxy;
+import net.minecraft.entity.item.EntityMinecart;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.items.IItemHandler;
+
+public class ProxyRailcraft implements ModProxy {
+    static final String MOD_ID = "railcraft";
+    public static ITrainHelper trainHelper = new ITrainHelper() {
+        @Override
+        public IItemHandler getTrainItemHandler(EntityMinecart cart) {
+            return null;
+        }
+
+        @Override
+        public IFluidHandler getTrainFluidHandler(EntityMinecart cart) {
+            return null;
+        }
+    };
+
+    @Override
+    public boolean isAvailable() {
+        return Loader.isModLoaded(MOD_ID);
+    }
+
+    @Override
+    public void init(final FMLInitializationEvent event) {
+        trainHelper = new TrainHelper();
+    }
+
+    public interface ITrainHelper {
+        IItemHandler getTrainItemHandler(EntityMinecart cart);
+        IFluidHandler getTrainFluidHandler(EntityMinecart cart);
+    }
+}

--- a/src/main/java/li/cil/architect/common/integration/railcraft/TrainHelper.java
+++ b/src/main/java/li/cil/architect/common/integration/railcraft/TrainHelper.java
@@ -8,10 +8,19 @@ import net.minecraftforge.items.IItemHandler;
 public class TrainHelper implements ProxyRailcraft.ITrainHelper {
     @Override
     public IItemHandler getTrainItemHandler(EntityMinecart cart) {
-        return CartToolsAPI.transferHelper.getTrainItemHandler(cart);
+        try {
+            return CartToolsAPI.transferHelper.getTrainItemHandler(cart);
+        } catch (Throwable ignored) {
+        }
+        return null;
     }
+
     @Override
     public IFluidHandler getTrainFluidHandler(EntityMinecart cart) {
-        return CartToolsAPI.transferHelper.getTrainFluidHandler(cart);
+        try {
+            return CartToolsAPI.transferHelper.getTrainFluidHandler(cart);
+        } catch (Throwable ignored) {
+        }
+        return null;
     }
 }

--- a/src/main/java/li/cil/architect/common/integration/railcraft/TrainHelper.java
+++ b/src/main/java/li/cil/architect/common/integration/railcraft/TrainHelper.java
@@ -1,0 +1,17 @@
+package li.cil.architect.common.integration.railcraft;
+
+import mods.railcraft.api.carts.CartToolsAPI;
+import net.minecraft.entity.item.EntityMinecart;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandler;
+
+public class TrainHelper implements ProxyRailcraft.ITrainHelper {
+    @Override
+    public IItemHandler getTrainItemHandler(EntityMinecart cart) {
+        return CartToolsAPI.transferHelper.getTrainItemHandler(cart);
+    }
+    @Override
+    public IFluidHandler getTrainFluidHandler(EntityMinecart cart) {
+        return CartToolsAPI.transferHelper.getTrainFluidHandler(cart);
+    }
+}

--- a/src/main/java/li/cil/architect/common/item/AbstractProvider.java
+++ b/src/main/java/li/cil/architect/common/item/AbstractProvider.java
@@ -7,6 +7,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -49,6 +50,7 @@ public abstract class AbstractProvider extends AbstractItem {
 
     static {
         MinecraftForge.EVENT_BUS.register(new Object() {
+            // We use this event because itemInteractionForEntity only applies to living entities, not minecarts.
             @SubscribeEvent
             public void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
                 EntityPlayer player = event.getEntityPlayer();
@@ -166,9 +168,9 @@ public abstract class AbstractProvider extends AbstractItem {
 
     // --------------------------------------------------------------------- //
 
-    abstract protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side);
+    abstract public boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side);
 
-    abstract protected boolean isValidTarget(final Entity entity);
+    abstract public boolean isValidTarget(final Entity entity);
 
     abstract protected String getTooltip();
 
@@ -281,12 +283,19 @@ public abstract class AbstractProvider extends AbstractItem {
                 final NBTTagCompound dataNbt = getDataTag(stack);
                 dataNbt.removeTag(TAG_DIMENSION);
                 dataNbt.removeTag(TAG_POSITION);
-                dataNbt.removeTag(TAG_ENTITY_UUID);
+                dataNbt.removeTag(TAG_ENTITY_UUID + "Most");
+                dataNbt.removeTag(TAG_ENTITY_UUID + "Least");
                 dataNbt.removeTag(TAG_SIDE);
                 player.inventory.markDirty();
             }
             return new ActionResult<>(EnumActionResult.SUCCESS, stack);
         }
         return new ActionResult<>(EnumActionResult.PASS, stack);
+    }
+
+    @Override
+    public boolean itemInteractionForEntity(ItemStack stack, EntityPlayer playerIn, EntityLivingBase target, EnumHand hand) {
+        // This is required to prevent onItemRightClick being called when interacting with entities.
+        return true;
     }
 }

--- a/src/main/java/li/cil/architect/common/item/AbstractProvider.java
+++ b/src/main/java/li/cil/architect/common/item/AbstractProvider.java
@@ -2,9 +2,11 @@ package li.cil.architect.common.item;
 
 import li.cil.architect.common.config.Constants;
 import li.cil.architect.common.config.Settings;
+import li.cil.architect.util.ItemStackUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,14 +18,20 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandler;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 
@@ -34,9 +42,33 @@ public abstract class AbstractProvider extends AbstractItem {
     // NBT tag names.
     private static final String TAG_DIMENSION = "dimension";
     private static final String TAG_POSITION = "position";
+    private static final String TAG_ENTITY_UUID = "entity";
     private static final String TAG_SIDE = "side";
 
     // --------------------------------------------------------------------- //
+
+    static {
+        MinecraftForge.EVENT_BUS.register(new Object() {
+            @SubscribeEvent
+            public void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
+                EntityPlayer player = event.getEntityPlayer();
+
+                Entity entity = event.getTarget();
+
+                ItemStack stack = event.getItemStack();
+                World world = player.world;
+                if (player.isSneaking() && !world.isRemote
+                        && !ItemStackUtils.isEmpty(stack) && stack.getItem() instanceof AbstractProvider
+                        && entity != null && ((AbstractProvider) stack.getItem()).isValidTarget(entity)) {
+                    final NBTTagCompound dataNbt = getDataTag(stack);
+                    dataNbt.setInteger(TAG_DIMENSION, world.provider.getDimension());
+                    dataNbt.setUniqueId(TAG_ENTITY_UUID, entity.getUniqueID());
+                    player.inventory.markDirty();
+                    event.setCanceled(true);
+                }
+            }
+        });
+    }
 
     AbstractProvider() {
         setMaxStackSize(1);
@@ -48,17 +80,29 @@ public abstract class AbstractProvider extends AbstractItem {
      * @param stack the provider to check for.
      * @return <code>true</code> if the provider is bound; <code>false</code> otherwise.
      */
-    public static boolean isBound(final ItemStack stack) {
+    public static boolean isBoundToBlock(final ItemStack stack) {
         final NBTTagCompound dataNbt = getDataTag(stack);
         return dataNbt.hasKey(TAG_DIMENSION, NBT.TAG_INT) &&
-               dataNbt.hasKey(TAG_POSITION, NBT.TAG_LONG) &&
-               dataNbt.hasKey(TAG_SIDE, NBT.TAG_BYTE);
+                dataNbt.hasKey(TAG_POSITION, NBT.TAG_LONG) &&
+                dataNbt.hasKey(TAG_SIDE, NBT.TAG_BYTE);
+    }
+
+    /**
+     * Check whether this provider is currently bound to an entity.
+     *
+     * @param stack the provider to check for.
+     * @return <code>true</code> if the provider is bound; <code>false</code> otherwise.
+     */
+    public static boolean isBoundToEntity(final ItemStack stack) {
+        final NBTTagCompound dataNbt = getDataTag(stack);
+        return dataNbt.hasKey(TAG_DIMENSION, NBT.TAG_INT) &&
+                dataNbt.hasUniqueId(TAG_ENTITY_UUID);
     }
 
     /**
      * Get the dimension the position the provider is bound to is in.
      * <p>
-     * Behavior is undefined if {@link #isBound(ItemStack)} returns <code>false</code>.
+     * Behavior is undefined if {@link #isBoundToBlock(ItemStack)} returns <code>false</code>.
      *
      * @param stack the provider to get the dimension for.
      * @return the dimension of the position the provider is bound to.
@@ -71,7 +115,7 @@ public abstract class AbstractProvider extends AbstractItem {
     /**
      * Get the position the provider is bound to.
      * <p>
-     * Behavior is undefined if {@link #isBound(ItemStack)} returns <code>false</code>.
+     * Behavior is undefined if {@link #isBoundToBlock(ItemStack)} returns <code>false</code>.
      *
      * @param stack the provider to get the position for.
      * @return the position the provider is bound to.
@@ -82,9 +126,35 @@ public abstract class AbstractProvider extends AbstractItem {
     }
 
     /**
+     * Get the entity the provider is bound to.
+     * <p>
+     * Behavior is undefined if {@link #isBoundToBlock(ItemStack)} returns <code>false</code>.
+     *
+     * @param stack the provider to get the position for.
+     * @return the position the provider is bound to.
+     */
+    @Nullable
+    public static Entity getEntity(final ItemStack stack, World world) {
+        final NBTTagCompound dataNbt = getDataTag(stack);
+        if (dataNbt.hasUniqueId(TAG_ENTITY_UUID)) {
+            UUID entityId = dataNbt.getUniqueId(TAG_ENTITY_UUID);
+            if (world instanceof WorldServer) {
+                //noinspection ConstantConditions
+                return ((WorldServer) world).getEntityFromUuid(entityId);
+            } else {
+                for (Entity entity : world.getLoadedEntityList()) {
+                    if (entity.getPersistentID().equals(entityId))
+                        return entity;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * Get the side of the block the provider is bound to.
      * <p>
-     * Behavior is undefined if {@link #isBound(ItemStack)} returns <code>false</code>.
+     * Behavior is undefined if {@link #isBoundToBlock(ItemStack)} returns <code>false</code>.
      *
      * @param stack the provider to get the bound-to side for.
      * @return the side the provider is bound to.
@@ -98,6 +168,8 @@ public abstract class AbstractProvider extends AbstractItem {
 
     abstract protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side);
 
+    abstract protected boolean isValidTarget(final Entity entity);
+
     abstract protected String getTooltip();
 
     /**
@@ -110,13 +182,13 @@ public abstract class AbstractProvider extends AbstractItem {
      * @param capabilityGetter extracts a capability from a tile entity.
      * @return the list of valid capabilities available.
      */
-    static <T> List<T> findProviders(final Vec3d consumerPos, final IItemHandler inventory, final Predicate<ItemStack> providerFilter, BiFunction<ItemStack, TileEntity, T> capabilityGetter) {
+    static <T> List<T> findProviders(final Vec3d consumerPos, final IItemHandler inventory, final Predicate<ItemStack> providerFilter, BiFunction<ItemStack, TileEntity, T> capabilityGetter, BiFunction<ItemStack, Entity, T> entityCapabilityGetter) {
         final List<T> result = new ArrayList<>();
 
         final float rangeSquared = Settings.maxProviderRadius * Settings.maxProviderRadius;
         for (int slot = 0; slot < inventory.getSlots(); slot++) {
             final ItemStack stack = inventory.getStackInSlot(slot);
-            if (!providerFilter.test(stack) || !isBound(stack)) {
+            if (!providerFilter.test(stack) || !(isBoundToBlock(stack) || isBoundToEntity(stack))) {
                 continue;
             }
 
@@ -126,20 +198,35 @@ public abstract class AbstractProvider extends AbstractItem {
                 continue;
             }
 
-            final BlockPos pos = getPosition(stack);
+            BlockPos pos;
+            T capability = null;
+
+            Entity entity = getEntity(stack, (WorldServer) world);
+            if (entity != null) {
+                pos = entity.getPosition();
+            } else {
+                pos = getPosition(stack);
+            }
+
             if (consumerPos.squareDistanceTo(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) > rangeSquared) {
                 continue;
             }
-            if (!world.isBlockLoaded(pos)) {
-                continue;
+
+            if (entity != null) {
+                capability = entityCapabilityGetter.apply(stack, entity);
+            } else {
+                if (!world.isBlockLoaded(pos)) {
+                    continue;
+                }
+
+                final TileEntity tileEntity = world.getTileEntity(pos);
+                if (tileEntity == null) {
+                    continue;
+                }
+
+                capability = capabilityGetter.apply(stack, tileEntity);
             }
 
-            final TileEntity tileEntity = world.getTileEntity(pos);
-            if (tileEntity == null) {
-                continue;
-            }
-
-            final T capability = capabilityGetter.apply(stack, tileEntity);
             if (capability == null) {
                 continue;
             }
@@ -160,9 +247,14 @@ public abstract class AbstractProvider extends AbstractItem {
         final FontRenderer fontRenderer = Minecraft.getMinecraft().fontRendererObj;
         tooltip.addAll(fontRenderer.listFormattedStringToWidth(info, Constants.MAX_TOOLTIP_WIDTH));
 
-        if (isBound(stack)) {
+        if (isBoundToBlock(stack)) {
             final BlockPos pos = getPosition(stack);
             tooltip.add(I18n.format(Constants.TOOLTIP_PROVIDER_TARGET, pos.getX(), pos.getY(), pos.getZ()));
+        } else if (isBoundToEntity(stack)) {
+            Entity entity = getEntity(stack, player.world);
+            if (entity != null) {
+                tooltip.add(String.format("Bound to %s", entity.getDisplayName().getFormattedText()));
+            }
         }
     }
 
@@ -189,6 +281,7 @@ public abstract class AbstractProvider extends AbstractItem {
                 final NBTTagCompound dataNbt = getDataTag(stack);
                 dataNbt.removeTag(TAG_DIMENSION);
                 dataNbt.removeTag(TAG_POSITION);
+                dataNbt.removeTag(TAG_ENTITY_UUID);
                 dataNbt.removeTag(TAG_SIDE);
                 player.inventory.markDirty();
             }

--- a/src/main/java/li/cil/architect/common/item/ItemProviderFluid.java
+++ b/src/main/java/li/cil/architect/common/item/ItemProviderFluid.java
@@ -6,6 +6,8 @@ import li.cil.architect.common.integration.railcraft.ProxyRailcraft;
 import li.cil.architect.util.FluidHandlerUtils;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.entity.monster.IMob;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -34,17 +36,16 @@ public final class ItemProviderFluid extends AbstractProvider {
     // AbstractProvider
 
     @Override
-    protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
+    public boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
         final IFluidHandler capability = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
         return capability != null && FluidHandlerUtils.canDrain(capability);
-
     }
 
     @Override
-    protected boolean isValidTarget(final Entity entity) {
+    public boolean isValidTarget(final Entity entity) {
         final IFluidHandler capability = entity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, null);
-        return capability != null && FluidHandlerUtils.canDrain(capability);
-
+        return !(entity instanceof EntityPlayer) && !(entity instanceof IMob)
+                && capability != null && FluidHandlerUtils.canDrain(capability);
     }
 
     @Override

--- a/src/main/java/li/cil/architect/common/item/ItemProviderFluid.java
+++ b/src/main/java/li/cil/architect/common/item/ItemProviderFluid.java
@@ -2,7 +2,10 @@ package li.cil.architect.common.item;
 
 import li.cil.architect.common.config.Constants;
 import li.cil.architect.common.init.Items;
+import li.cil.architect.common.integration.railcraft.ProxyRailcraft;
 import li.cil.architect.util.FluidHandlerUtils;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -24,7 +27,7 @@ public final class ItemProviderFluid extends AbstractProvider {
      * @return the list of valid fluid handlers available.
      */
     public static List<IFluidHandler> findProviders(final Vec3d consumerPos, final IItemHandler inventory) {
-        return AbstractProvider.findProviders(consumerPos, inventory, Items::isFluidProvider, ItemProviderFluid::getFluidHandlerCapability);
+        return AbstractProvider.findProviders(consumerPos, inventory, Items::isFluidProvider, ItemProviderFluid::getFluidHandlerCapability, ItemProviderFluid::getFluidHandlerCapability);
     }
 
     // --------------------------------------------------------------------- //
@@ -33,11 +36,15 @@ public final class ItemProviderFluid extends AbstractProvider {
     @Override
     protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
         final IFluidHandler capability = tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
-        if (capability == null) {
-            return false;
-        }
+        return capability != null && FluidHandlerUtils.canDrain(capability);
 
-        return FluidHandlerUtils.canDrain(capability);
+    }
+
+    @Override
+    protected boolean isValidTarget(final Entity entity) {
+        final IFluidHandler capability = entity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, null);
+        return capability != null && FluidHandlerUtils.canDrain(capability);
+
     }
 
     @Override
@@ -50,5 +57,16 @@ public final class ItemProviderFluid extends AbstractProvider {
     @Nullable
     private static IFluidHandler getFluidHandlerCapability(final ItemStack stack, final TileEntity tileEntity) {
         return tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, getSide(stack));
+    }
+
+    @Nullable
+    private static IFluidHandler getFluidHandlerCapability(final ItemStack stack, final Entity entity) {
+        IFluidHandler fluidHandler = null;
+        if (entity instanceof EntityMinecart)
+            fluidHandler = ProxyRailcraft.trainHelper.getTrainFluidHandler((EntityMinecart) entity);
+        if (fluidHandler == null && entity.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, null)) {
+            fluidHandler = entity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, null);
+        }
+        return fluidHandler;
     }
 }

--- a/src/main/java/li/cil/architect/common/item/ItemProviderItem.java
+++ b/src/main/java/li/cil/architect/common/item/ItemProviderItem.java
@@ -5,6 +5,8 @@ import li.cil.architect.common.init.Items;
 import li.cil.architect.common.integration.railcraft.ProxyRailcraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityMinecart;
+import net.minecraft.entity.monster.IMob;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -33,13 +35,14 @@ public final class ItemProviderItem extends AbstractProvider {
     // AbstractProvider
 
     @Override
-    protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
+    public boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
         return tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
     }
 
     @Override
-    protected boolean isValidTarget(final Entity entity) {
-        return entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+    public boolean isValidTarget(final Entity entity) {
+        return !(entity instanceof EntityPlayer) && !(entity instanceof IMob)
+                && entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
     }
 
     @Override

--- a/src/main/java/li/cil/architect/common/item/ItemProviderItem.java
+++ b/src/main/java/li/cil/architect/common/item/ItemProviderItem.java
@@ -2,6 +2,9 @@ package li.cil.architect.common.item;
 
 import li.cil.architect.common.config.Constants;
 import li.cil.architect.common.init.Items;
+import li.cil.architect.common.integration.railcraft.ProxyRailcraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -22,7 +25,8 @@ public final class ItemProviderItem extends AbstractProvider {
      * @return the list of valid item handlers available.
      */
     public static List<IItemHandler> findProviders(final Vec3d consumerPos, final IItemHandler inventory) {
-        return AbstractProvider.findProviders(consumerPos, inventory, Items::isItemProvider, ItemProviderItem::getItemHandlerCapability);
+        return AbstractProvider.findProviders(consumerPos, inventory, Items::isItemProvider,
+                ItemProviderItem::getItemHandlerCapability, ItemProviderItem::getItemHandlerCapability);
     }
 
     // --------------------------------------------------------------------- //
@@ -31,6 +35,11 @@ public final class ItemProviderItem extends AbstractProvider {
     @Override
     protected boolean isValidTarget(final TileEntity tileEntity, final EnumFacing side) {
         return tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
+    }
+
+    @Override
+    protected boolean isValidTarget(final Entity entity) {
+        return entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
     }
 
     @Override
@@ -43,5 +52,16 @@ public final class ItemProviderItem extends AbstractProvider {
     @Nullable
     private static IItemHandler getItemHandlerCapability(final ItemStack stack, final TileEntity tileEntity) {
         return tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, getSide(stack));
+    }
+
+    @Nullable
+    private static IItemHandler getItemHandlerCapability(final ItemStack stack, final Entity entity) {
+        IItemHandler itemHandler = null;
+        if (entity instanceof EntityMinecart)
+            itemHandler = ProxyRailcraft.trainHelper.getTrainItemHandler((EntityMinecart) entity);
+        if (itemHandler == null && entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)) {
+            itemHandler = entity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+        }
+        return itemHandler;
     }
 }


### PR DESCRIPTION
This PR allows you to use Item and Fluid Providers on entities. This includes Minecarts, Mules, and any other non-hostile or player entity.

Overlay rendering is fully supported.

It also adds a hook into Railcraft's train code so that a single provider can interface with an entire train. This introduces a soft-compile time dependency on Railcraft, but doesn't require you to ship anything and doesn't force users to install Railcraft.